### PR TITLE
No LinuxCommConnection src in the repo

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -101,8 +101,6 @@ find_package(rapidjson REQUIRED)
 ## Declare things to be passed to dependent projects
 ## INCLUDE_DIRS: uncomment this if your package contains header files
 ## LIBRARIES: libraries you create in this project that dependent projects also need
-## CATKIN_DEPENDS: catkin_packages dependent projects also need
-## DEPENDS: system dependencies of this project that dependent projects also need
 catkin_package(
 #  INCLUDE_DIRS include
 #  LIBRARIES radar_data
@@ -110,19 +108,9 @@ catkin_package(
 #  DEPENDS system_lib
 )
 
-set(COMMDIR src/LinuxCommConnection/src/)
-add_subdirectory(${COMMDIR})
-set(COMLIB 
-	${COMMDIR}SerialConnection.h 
-	${COMMDIR}SerialConnection.cpp 
-	${COMMDIR}CommConnection.h 
-	${COMMDIR}CommConnection.cpp 
-	#${COMMDIR}Linux/SerialConnection.cpp 
-	#PARENT_SCOPE
-)
-
-add_executable(radar_publisher src/radar_publisher.cpp ${COMLIB})
-target_link_libraries(radar_publisher ${catkin_LIBRARIES} ${RAPIDJSONDIR})
+set(LCC_LINK_FLAG "-lLinuxCommConnection")
+add_executable(radar_publisher src/radar_publisher.cpp)
+target_link_libraries(radar_publisher ${catkin_LIBRARIES} ${RAPIDJSONDIR} ${LCC_LINK_FLAG})
 add_dependencies(radar_publisher OPS241A_radar_generate_messages_cpp)
 
 ##add_executable(radar_subscriber src/radar_subscriber.cpp)

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # OPS-ShortRangeRadar
 Robotic Operating System (ROS) publisher and service for the OmniPreSense short range radar (originally OPS241-A)
 
-You will need to download the rapidJson library from the Tencent github found here: https://github.com/Tencent/rapidjson
-type make_install to install
+You will need to download and install:
+	[rapidJson]( https://github.com/Tencent/rapidjson)
+	[LinuxCommConnection](https://github.com/RyanLoringCooper/LinuxCommConnection)

--- a/src/radar_publisher.cpp
+++ b/src/radar_publisher.cpp
@@ -21,9 +21,8 @@
 #include <sstream> 
 #include <string>
 #include <thread>
-#include "LinuxCommConnection/src/CommConnection.h"
-#include "LinuxCommConnection/src/SerialConnection.h"
-#include "LinuxCommConnection/src/NetworkConnection.h"
+#include <LinuxCommConnection/CommConnection.h>
+#include <LinuxCommConnection/SerialConnection.h>
 #include "rapidjson/document.h"
 
 using namespace rapidjson;


### PR DESCRIPTION
The changes on this branch removed LinuxCommConnection(LCC) src in the repo and its associated stuff in the CMakeLists.txt. I added the necessary things to link against LCC to the CMakeLists.txt. I modified README.md to have links to the repos that this repo is dependent on. I think it is best that we leave out instructions on how to install those dependencies because they may change. I tested that these changes did not break anything.

The major change is that the user will have to checkout LCC and run make install. 

When you are happy with what I have changed, you can hit the green "Merge pull request" to put my changes into master. After this is merged, I would like to delete the LCC fork in this organization as it is not ROS related.